### PR TITLE
Fixes issue #69

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -25,7 +25,8 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-latest
+    # reduce runtime requirements from libc/libc++
+    runs-on: ubuntu-20.04
     # container:
     #   image: ghcr.io/${{ github.repository }}/oci_kuksa-val-services-ci:v0.1.0
     #   credentials:
@@ -78,7 +79,11 @@ jobs:
           HVAC_TAG: "prerelease"
         run: |
           ./integration_test/it-setup.sh init
-          ./integration_test/it-setup.sh start
+          if ! ./integration_test/it-setup.sh start; then
+            echo "### Container startup failed logs:"
+            ./integration_test/it-setup.sh status --logs
+            exit 1
+          fi
           sleep 1
           ./integration_test/it-setup.sh status --logs
           # echo "$ docker image ls"

--- a/.github/workflows/scripts/install-ci-tooling.sh
+++ b/.github/workflows/scripts/install-ci-tooling.sh
@@ -54,3 +54,6 @@ pip3 install \
 # install docker
 # curl -fsSL https://get.docker.com -o - | bash -
 # docker --version
+
+echo "### Running on:"
+cat /etc/os-release

--- a/seat_service/Dockerfile
+++ b/seat_service/Dockerfile
@@ -12,7 +12,7 @@
 # ********************************************************************************/
 
 
-FROM --platform=$BUILDPLATFORM alpine:latest as builder
+FROM --platform=$BUILDPLATFORM ubuntu:20.04 as builder
 
 ARG TARGETPLATFORM
 
@@ -27,12 +27,13 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; \
     then tar -xf bin_vservice-seat_x86_64_release.tar.gz && cp -rv ./target/x86_64/release/install/ ./bins; \
     else tar -xf bin_vservice-seat_aarch64_release.tar.gz && cp -rv ./target/aarch64/release/install/ ./bins; fi
 
-FROM --platform=$TARGETPLATFORM ubuntu:latest as runtime
+FROM --platform=$TARGETPLATFORM ubuntu:20.04 as runtime
 
 LABEL org.opencontainers.image.description "VAL Seat Service container, providing VSC Seat impl and supporting simulated/real can ECU"
 
 ## Uncomment for ip/can tools
 #RUN apt-get -qqy update && apt-get install -qqy net-tools can-utils iproute2 && apt clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get -qqy update && apt-get install --no-install-recommends can-utils && apt clean && rm -rf /var/lib/apt/lists/*
 # make sure localhost can be resolved!
 RUN cat /etc/hosts | grep -q localhost || echo "127.0.0.1 localhost" >> /etc/hosts
 
@@ -42,6 +43,8 @@ WORKDIR /app/bin
 
 ### "cansim" is special value for using SeatAdjuster CAN simulator (even without vcan support in container)
 ENV CAN=cansim
+### if set to 1, forces running ecu-reset script on startup that does not work with cansim and also delays 3s the startup of can stup without actual Seat ECU
+# ENV SC_RESET=0
 
 ### [vxcan] options
 # By default, wait for can-forward.sh to move vxcan1 in container's namespace after container start

--- a/seat_service/src/lib/seat_adjuster/seat_controller/README.md
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/README.md
@@ -13,9 +13,10 @@ It is possible to have a small (~1%) "overshoot" in position.
 
 To maximize flexibility SeatController uses environment variables to easily override default configuration.
 
-- `SC_CAN`: If set, overrides requested can interface to use.
+- `SC_CAN`: If set, overrides requested can interface to use. (Not used if `seat_service` is started with `<can_if_name>` argument)
+- `SC_RESET`: if set to "1", forces calling `ecu-reset` script on any `CAN` interface (Default 1).
 - `SC_TIMEOUT`: Seat adjuster move operation timeout (ms). After it is reached motors are stopped.
-- `SC_STAT`: "1" = dump SECU1_STAT can frames (useful to check for unmanaged seat position changes)
+- `SC_STAT`: "1" = dump SECU1_STAT can frames (useful to check for unmanaged seat position changes).
 - `SC_CTL`: "1" = dump Coontrol Loop messages. Only dumps when active set position operation is running.
 - `SC_RPM`: Seat moror `RPMs / 100`. e.g. `80=8000rpm`. Suggested range `[30..100]`
 - `SC_RAW`: "1" = enables raw can dumps, too verbose (only for troubleshooting).

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tests/cansim/cansim_lib.c
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tests/cansim/cansim_lib.c
@@ -178,7 +178,7 @@ void _initialize(void) {
         exit(1);
     }
     // dlclose(handle);
-    fprintf(sim_log, SELF_INIT "Initialized successfully.");
+    fprintf(sim_log, SELF_INIT "Initialized successfully.\n");
     fprintf(sim_log, "WARNING: Hooked libc socket(),bind(),read(),write(),ioctl(),setsockopt(),close() ...\n");
 
     sim_initialized = true;

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/README.md
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/README.md
@@ -63,7 +63,6 @@ Runs the motors in endless increasing / decreasing position loop with specified 
 - _rpm_ values below 30 (3000 rpm) are too low to start moving.
 - _rpm_ values above 120 (12000 rpm) no longer increase the speed of movement.
 
-
 ## Scripts for testing without CAN HW
 
 ### `setup-vcan`
@@ -74,17 +73,20 @@ Both `grpc` server and `sim-SECU1_STAT` should run on `vcan0`.
 
 ### `sim-SECU1_STAT`
 
-  Simulate `SECU1_STAT.motor1_pos` changing from _[0..100]_ and _[100..0]_
+Simulate `SECU1_STAT.motor1_pos` changing from _[0..100]_ and _[100..0]_
 
-  This script is required if you don't have CAN hardware for Seat Adjuster as Control Loop requires a defined initial `motor1_pos` to initiate the move command.
+This script is required if you don't have CAN hardware for Seat Adjuster as Control Loop requires a defined initial `motor1_pos` to initiate the move command.
 
-  **NOTE:** It is recommended to run both `hal_service` and `sim-SECU1_STAT` on `vcan0`.
+    Usage: ./sim-SECU1_STAT {-i iterations} {-t timeout_sec} {-r} <can_if>
+        can_if: CAN interface to use. Default: vcan0
+        -i: Force calibration even if motor reports learned state. Default: 0
+        -t: timeout in seconds to abort operation. Default: 5 sec
+        -r: Simulate ECU reset (start in unlearned state)
+        -v: prints generated cansend commands
+        -h: Prints this message
 
-    Usage: ./sim-SECU1_STAT <can_if> {iterations} {verbose}
-        can_if - use specified can interface. Default: vcan0
-        iterations - runs pos change [0..100]-[100..0] in a loop. 0=infinite, Default: 0
-        verbose - if 3rd arg is provided - prints generated cansend commands
-
+**NOTE:** It is recommended to run both `seat_service` and `sim-SECU1_STAT` on `vcan0`.
+Simulation of ECU reset (motor in unlearned state) is possible with `-r` option
 
 ## CAN Troubleshooting scripts
 

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/cangen-SECU1_STAT
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/cangen-SECU1_STAT
@@ -25,6 +25,6 @@ CAN=$1
 TIMEOUT=$2
 [ -z "$TIMEOUT" ] && TIMEOUT=1000
 
-cangen -v $CAN -L 8 -I 712 -D r -g $TIMEOUT
+cangen -v "$CAN" -L 8 -I 712 -D r -g "$TIMEOUT"
 
 

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/cansim
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/cansim
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #********************************************************************************
 # Copyright (c) 2022 Contributors to the Eclipse Foundation
 #
@@ -12,7 +12,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #*******************************************************************************/
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 if [ $# -eq 0 ]; then
     echo "Usage $0 <command> {arg0} {arg1} .."

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/ecu-reset
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/ecu-reset
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #********************************************************************************
 # Copyright (c) 2022 Contributors to the Eclipse Foundation
 #
@@ -11,6 +11,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #*******************************************************************************/
+# shellcheck disable=SC2181
 
 # how many can read timeouts are accepted before bailing out (no can hw)
 MAX_RETRIES=3
@@ -22,6 +23,7 @@ TIMEOUT=60
 STAT=0
 VERBOSE=0
 FORCE=0
+CAN="can0"
 
 while [ $# -gt 0 ]; do
     if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
@@ -47,107 +49,105 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-#CAN="$1"
-[ -z "$CAN" ] && CAN="can0"
-
 echo "### Normalizing SeatAdjust ECU on $CAN"
 
 
 motor_off() {
-    frame=`printf "cansend $CAN 705#00.00.00.00.00.00.00.00"`
-    echo "TX: [motor-OFF] $frame"
-    `$frame`
+    _frame=$(printf "cansend %s 705#00.00.00.00.00.00.00.00" "$CAN")
+    echo "TX: [motor-OFF] $_frame"
+    eval "$_frame"
     sleep 0.5
 }
 
 motor_inc() {
-    local rpm=$1
-    frame=`printf "cansend $CAN 705#02.%02X.00.00.00.00.00.00" $rpm`
-    echo "TX: [motor-INC] $frame"
-    `$frame`
+    _rpm="$1"
+    _frame=$(printf "cansend %s 705#02.%02X.00.00.00.00.00.00" "$CAN" "$_rpm")
+    echo "TX: [motor-INC] $_frame"
+    eval "$_frame"
     sleep 0.2
 }
 
 motor_dec() {
-    local rpm=$1
-    frame=`printf "cansend $CAN 705#01.%02X.00.00.00.00.00.00" $rpm`
-    echo "TX: [motor-DEC] $frame"
-    `$frame`
+    _rpm="$1"
+    _frame=$(printf "cansend %s 705#01.%02X.00.00.00.00.00.00" "$CAN" "$_rpm")
+    echo "TX: [motor-DEC] $_frame"
+    eval "$_frame"
     sleep 0.2
 }
 
 read_can_frame() {
-    local can=$1
-    candump -T 1000 -n 1 -L $can,712:7FF | cut -d ' ' -f 3
+    _can="$1"
+    candump -T 1000 -n 1 -L "$_can",712:7FF | cut -d ' ' -f 3
 }
 
 parse_motor_pos() {
-    local frame="$1"
+    _frame="$1"
     # only handle 0x712 canid
-    if [ "${frame:0:4}" != "712#" ]; then
+    if [ "$(echo "$_frame" | cut -c-4)" != "712#" ]; then  # "{frame:0:4}"
         return 1;
     fi
-    local data=${frame#*#}
+    _data="${_frame#*#}"
     # pos_hex is 3rd byte
-    pos_hex=${data:4:2}
-    echo $(( 0x${pos_hex} ))
+    _pos_hex=$(echo "$_data" | cut -c5-6) # "{data:4:2}"
+    echo "$(( 0x${_pos_hex} ))"
     return 0
 }
 
 parse_motor_mov() {
-    local frame="$1"
+    _frame="$1"
     # only handle 0x712 canid
-    if [ "${frame:0:4}" != "712#" ]; then
+    if [ "$(echo "$_frame" | cut -c-4)" != "712#" ]; then  # "{frame:0:4}"
         return 1;
     fi
-    local data=${frame#*#}
+    _data="${_frame#*#}"
     # mov_hex is 2nd & 0x0F
-    mov_hex=${data:1:1}
-    #echo -n " ($mov_hex)="
-    case $(( $mov_hex & 0x03 )) in
+    _mov_hex=$(echo "$_data" | cut -c2) # "{data:1:1}"
+    case $(( _mov_hex & 0x03 )) in
         0) echo "OFF";;
         1) echo "DEC";;
         2) echo "INC";;
-        *) return 1;;
+        *) echo "INV"
+           return 1;;
     esac
     return 0
 }
 
 parse_motor_lrn() {
-    local frame="$1"
+    _frame="$1"
     # only handle 0x712 canid
-    if [ "${frame:0:4}" != "712#" ]; then
+    if [ "$(echo "$_frame" | cut -c -4)" != "712#" ]; then  # "{frame:0:4}"
         return 1;
     fi
-    local data=${frame#*#}
+    _data="${_frame#*#}"
     # mov_hex is 2nd & 0x0F
-    mov_hex=${data:1:1}
-    #echo -n " ($mov_hex)="
-    case $(( ($mov_hex >> 2) & 0x03 )) in
+    _mov_hex=$(echo "$_data" | cut -c2) # {data:1:1}
+    case $(( (_mov_hex >> 2) & 0x03 )) in
         0) echo "NOT";;
         1) echo "LRN";;
         2) echo "INV";;
-        *) return 1;;
+        *) echo "???"
+           return 1;;
     esac
     return 0
 }
 
 old_frame="---" # invalidate
 
-# FSM states
-state=0 # 0=motor_inc; 1=
+## normalization states
+# 0=motor_inc; 1=wait_off_motor_dec; 2=wait_off_motor_inc; 3=wait_off_finish
+state=0
 
 ts_start=$(date '+%s')
 failures=0
 while true; do
-    frame=`read_can_frame $CAN`
+    frame=$(read_can_frame "$CAN")
     if [ $? -ne 0 ]; then
         echo "Aborted. Can't read from $CAN ..."
         exit 1
     fi
     ts_now=$(date '+%s')
     ts_elapsed=$((ts_now - ts_start))
-    if [ $ts_elapsed -ge $TIMEOUT ]; then
+    if [ $ts_elapsed -ge "$TIMEOUT" ]; then
         echo "### Aborted after $ts_elapsed sec." 1>&2
         exit 1
     fi
@@ -158,6 +158,7 @@ while true; do
             echo "### Aborted (no can frames) after $ts_elapsed sec." 1>&2
             exit 2
          fi
+         continue
     else
         failures=0 # reset counter on incoming can frame...
     fi
@@ -166,9 +167,9 @@ while true; do
         continue
     fi
 
-    pos=`parse_motor_pos "$frame"`
-    mov=`parse_motor_mov "$frame"`
-    lrn=`parse_motor_lrn "$frame"`
+    pos=$(parse_motor_pos "$frame")
+    mov=$(parse_motor_mov "$frame")
+    lrn=$(parse_motor_lrn "$frame")
 
     [ -n "$frame" ] && [ "$STAT" = "1" ] && printf 'RX: SECU1_STAT {pos:%3d%% mov:%3s, lrn:%3s} \tframe: %s\n' "$pos" "$mov" "$lrn" "$frame"
     old_frame="$frame"
@@ -217,6 +218,7 @@ while true; do
             if [ "$mov" = "OFF" ]; then
                 echo "3: [*] Normalize finished"
                 state=4 # terminal state
+                echo "### Motor state: [$lrn]"
                 #old_frame=""
                 break
             else

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/motor-dec
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/motor-dec
@@ -22,13 +22,13 @@ rpm=$1
 [ -z "$rpm" ] && rpm=80
 
 # change manually if needed e.g. to "vcan0"
-CAN="can0"
+[ -z "$CAN" ] && CAN="can0"
 
 # stop motors (always required!)
 echo "cansend $CAN 705#00.00.00.00.00.00.00.00"
-cansend $CAN 705#00.00.00.00.00.00.00.00
+cansend "$CAN" "705#00.00.00.00.00.00.00.00"
 sleep 0.1
 
-BUF=`printf "705#01.%02X.00.00.00.00.00.00" $rpm`
+BUF=$(printf "705#01.%02X.00.00.00.00.00.00" "$rpm")
 echo "cansend $CAN $BUF"
-cansend $CAN $BUF
+cansend "$CAN" "$BUF"

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/motor-inc
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/motor-inc
@@ -22,13 +22,13 @@ rpm=$1
 [ -z "$rpm" ] && rpm=80
 
 # change manually if needed e.g. to "vcan0"
-CAN="can0"
+[ -z "$CAN" ] && CAN="can0"
 
 # stop motors (always required!)
 echo "cansend $CAN 705#00.00.00.00.00.00.00.00"
-cansend $CAN 705#00.00.00.00.00.00.00.00
+cansend "$CAN" 705#00.00.00.00.00.00.00.00
 sleep 0.1
 
-BUF=`printf "705#02.%02X.00.00.00.00.00.00" $rpm`
+BUF=$(printf "705#02.%02X.00.00.00.00.00.00" "$rpm")
 echo "cansend $CAN $BUF"
-cansend $CAN $BUF
+cansend "$CAN" "$BUF"

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/motor-stop
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/motor-stop
@@ -12,6 +12,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #*******************************************************************************/
 
-CAN="can0"
+# change manually if needed e.g. to "vcan0"
+[ -z "$CAN" ] && CAN="can0"
 
-cansend $CAN 705#00.00.00.00.00.00.00.00
+cansend "$CAN" "705#00.00.00.00.00.00.00.00"

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/motor-swipe
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/motor-swipe
@@ -29,10 +29,10 @@ echo "# Running on can: $CAN, timeout: $TIMEOUT"
 
 while true; do 
   echo ">>> Motor ++++"
-  cansend $CAN 705#00.00.00.00.00.00.00.00; sleep 0.1; cansend $CAN 705#02.50.00.00.00.00.00.00
-  sleep $TIMEOUT
+  cansend "$CAN" "705#00.00.00.00.00.00.00.00"; sleep 0.1; cansend "$CAN" "705#02.50.00.00.00.00.00.00"
+  sleep "$TIMEOUT"
   echo ">>> Motor ----"
-  cansend $CAN 705#00.00.00.00.00.00.00.00; sleep 0.1; cansend $CAN 705#01.50.00.00.00.00.00.00 
-  sleep $TIMEOUT
+  cansend "$CAN" "705#00.00.00.00.00.00.00.00"; sleep 0.1; cansend "$CAN" "705#01.50.00.00.00.00.00.00"
+  sleep "$TIMEOUT"
   echo "###############"
 done

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/setup-vcan
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/setup-vcan
@@ -17,10 +17,11 @@
 CAN=$1
 [ -z "$CAN" ] && CAN="vcan0"
 
-ifconfig $CAN 2>/dev/null | grep -q UP && exit 0
+# NOTE: needs `apt-get install net-tools iproute2 `
+ifconfig "$CAN" 2>/dev/null | grep -q UP && exit 0
 
 sudo modprobe vcan
-sudo sudo ip link add dev $CAN type vcan
-sudo sudo ip link set up $CAN
+sudo sudo ip link add dev "$CAN" type vcan
+sudo sudo ip link set up "$CAN"
 
-ifconfig $CAN
+ifconfig "$CAN"

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/sim-SECU1_STAT
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/sim-SECU1_STAT
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #********************************************************************************
 # Copyright (c) 2022 Contributors to the Eclipse Foundation
 #
@@ -12,50 +12,115 @@
 # SPDX-License-Identifier: Apache-2.0
 #*******************************************************************************/
 
+# Motor Move constants
+MOV_OFF=0
+MOV_DEC=1
+MOV_INC=2
 
-if [ "$1" = "--help" ]; then
-    echo "Usage: $0 <can_if> {iterations} {verbose}"
-    echo "	can_if - use specified can interface. Default: vcan0"
-    echo "	iterations - runs pos change [0..100]-[100..0] in a loop. 0=infinite, Default: 0"
-	echo "	verbose - if 3rd arg is provided - prints generated cansend commands"
-    exit 0
+# Motor learned constants
+STATE_NOT=0
+STATE_LRN=1
+
+
+# argument defaults
+CAN="vcan0"
+ITERATIONS=0
+TIMEOUT=1.0
+VERBOSE=0
+RESET=0
+
+while [ $# -gt 0 ]; do
+    if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+        echo "Usage: $0 {-i iterations} {-t timeout_sec} {-r} can_if"
+        echo "   can_if: CAN interface to use. Default: $CAN";
+        echo "   -i: Force calibration even if motor reports learned state. Default: $ITERATIONS";
+        echo "   -t: timeout in seconds to abort operation. Default: $TIMEOUT sec";
+        echo "   -r: Simulate ECU reset (start in unlearned state)";
+        echo "   -v: prints generated cansend commands";
+        echo "   -h: Prints this message";
+        exit 0
+    elif [ "$1" = "-v" ]; then
+        VERBOSE=1
+    elif [ "$1" = "-r" ]; then
+        RESET=1
+    elif [ "$1" = "-i" ]; then
+        shift # get next arg
+        ITERATIONS="$1"
+    elif [ "$1" = "-t" ]; then
+        shift # get next arg
+        TIMEOUT=$1
+    else
+        CAN="$1"
+    fi
+    shift
+done
+
+
+send_frame()
+{
+    _frame="$1"
+    [ "$VERBOSE" != "0" ] && echo "TX: $_frame"
+    eval "$_frame"
+    sleep 0.01
+    eval "$_frame"
+    sleep 0.01
+}
+
+send_secu1_stat()
+{
+    _mov="$1"
+    _lrn="$2"
+    _pos="$3"
+
+    # printf "### Sending SECU1_STAT [ MOTOR1_MOV_STATE:%d, MOTOR1_LEARNING_STATE:%d, MOTOR1_POS:%d ]\n" "$mov" "$lrn" "$pos" 1>&2
+
+    _nibble=$(( (_lrn & 0x3) * 4 | (_mov & 0x3) ))
+    _sframe=$(printf "cansend %s 712#0%d.00.%02X.00.00.00.00.00" "$CAN" $_nibble "$_pos")
+    send_frame "$_sframe"
+}
+
+if [ -n "$RESET" ]; then
+    # Simulate ECU reset, state unlearned
+    send_secu1_stat $MOV_OFF $STATE_NOT 0
+    LEARN_STATE=$STATE_NOT
+else
+    LEARN_STATE=$STATE_LRN
 fi
-
-CAN=$1
-[ -z "$CAN" ] && CAN="vcan0"
-
-ITERATIONS="$2" # optional, assume infinite
-[ -z "$ITERATIONS" ] && ITERATIONS=0
-
-VERBOSE="$3"
 
 echo "# Running $ITERATIONS interations on: $CAN ..."
 iter=0
-while [ $ITERATIONS -eq 0 ] || [ $iter -lt $ITERATIONS ]; do
-	echo
-	echo "### Sending SECU1_STAT [ MOTOR1_MOV_STATE: 'INC', MOTOR1_LEARNING_STATE: 'learned', MOTOR1_POS: 0..100 ]"
-	for pos in `seq 0 +1 100`; do
-		frame=`printf "cansend $CAN 712#46.44.%02X.00.00.00.00.00" $pos`
-		[ -n "$VERBOSE" ] && echo "$frame"
-		`$frame`
-		sleep 0.01
-		`$frame`
-		sleep 0.01
-	done
+while [ "$ITERATIONS" -eq 0 ] || [ $iter -lt "$ITERATIONS" ]; do
+    echo
+    echo "### Sending SECU1_STAT [ MOTOR1_MOV_STATE: 'DEC', MOTOR1_LEARNING_STATE: $LEARN_STATE, MOTOR1_POS: 100..0 ]"
+    for pos in $(seq 100 -1 0); do
+        #frame=$(printf "cansend %s 712#45.44.%02X.00.00.00.00.00" "$CAN" "$pos")
+        send_secu1_stat $MOV_DEC $LEARN_STATE "$pos"
+    done
+    [ "$VERBOSE" != "0" ] && echo
 
-	sleep 5
+    # Simulate learning mode after 3 full swipes
+    if [ $iter -eq 1 ] && [ $LEARN_STATE = $STATE_NOT ]; then
+        echo "// Setting Learned state"
+        LEARN_STATE=$STATE_LRN
+    fi
 
-	[ -n "$VERBOSE" ] && echo
-	echo "### Sending SECU1_STAT [ MOTOR1_MOV_STATE: 'DEC', MOTOR1_LEARNING_STATE: 'learned', MOTOR1_POS: 100..0 ]"
-	for pos in `seq 100 -1 0`; do
-		frame=`printf "cansend $CAN 712#45.44.%02X.00.00.00.00.00" $pos`
-		[ -n "$VERBOSE" ] && echo "$frame"
-		`$frame`
-		sleep 0.01
-		`$frame`
-		sleep 0.01
-	done
-	[ -n "$VERBOSE" ] && echo
+    # Motor OFF
+    echo "### Sending SECU1_STAT [ MOTOR1_MOV_STATE: 'OFF', MOTOR1_LEARNING_STATE: $LEARN_STATE, MOTOR1_POS: $pos"
+    send_secu1_stat $MOV_OFF $LEARN_STATE "$pos"
 
-	((iter=iter+1))
+    sleep "$TIMEOUT"
+
+    echo "### Sending SECU1_STAT [ MOTOR1_MOV_STATE: 'INC', MOTOR1_LEARNING_STATE: $LEARN_STATE, MOTOR1_POS: 0..100 ]"
+    for pos in $(seq 0 +1 100); do
+        #frame=$(printf "cansend %s 712#46.44.%02X.00.00.00.00.00" "$CAN" "$pos")
+        send_secu1_stat $MOV_INC $LEARN_STATE "$pos"
+    done
+    [ "$VERBOSE" != "0" ] && echo
+
+    iter=$(( iter+1 ))
+
+    # Motor OFF
+    echo "### Sending SECU1_STAT [ MOTOR1_MOV_STATE: 'OFF', MOTOR1_LEARNING_STATE: $LEARN_STATE, MOTOR1_POS: $pos"
+    send_secu1_stat $MOV_OFF $LEARN_STATE "$pos"
+
 done

--- a/seat_service/src/lib/seat_adjuster/seat_controller/tools/val_start.sh
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/tools/val_start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #********************************************************************************
 # Copyright (c) 2022 Contributors to the Eclipse Foundation
 #
@@ -13,7 +13,7 @@
 #*******************************************************************************/
 # shellcheck disable=SC2086
 
-INSTALL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL="$(cd "$(dirname "$0")" && pwd)"
 
 # Used can interface, if hw is missing set it to "vcan0" and run:
 #   ~/vehicle_hal/tools/setup-vcan; ~/vehicle_hal/tools/sim-SECU1_STAT vcan0 0
@@ -35,17 +35,17 @@ sig_handler() {
 	exit 42
 }
 
-trap sig_handler SIGTERM SIGINT
+trap sig_handler TERM INT
 
 ### Wait for can device available
 if [ -n "$CAN_WAIT" ] && [ "$CAN" != "cansim" ]; then
 	echo "[$0] Waiting for $CAN ($CAN_WAIT s)..."
 	# avoid ip tool dependency
 	sec=0
-	while [ ! -e /sys/class/net/$CAN ]; do
+	while [ ! -e "/sys/class/net/$CAN" ]; do
 		sleep 1
 		sec=$((sec + 1))
-		if [ $sec -ge $CAN_WAIT ]; then
+		if [ $sec -ge "$CAN_WAIT" ]; then
 			echo "[$0] Timedout waiting for: /sys/class/net/$CAN"
 			exit 3
 		fi
@@ -73,8 +73,13 @@ fi
 
 # 1=Exit process on CAN I/O or other fatal error
 [ -z "$SA_EXIT" ] && export SA_EXIT=1
+
+# Enforce ecu-reset on any CAN interface
+#[ -z "$SC_RESET" ] && export SC_RESET=0
+
 # attempt to do grpc cleanup on exit (may hang the exit!)
 #export GRPC_CLEANUP=1
+
 
 ### DataFeeder configuration ###
 
@@ -94,17 +99,16 @@ fi
 [ -z "$SERVICE_HOST" ] && SERVICE_HOST="0.0.0.0"
 [ -z "$SERVICE_PORT" ] && SERVICE_PORT=50051
 
-### Calibrate motor before service start (needs to be done after ECU reset, or not in learned state )
-if [ "$CAN" = "can0" ]; then
-	echo "### Calibrating ECU on $CAN"
-	# timeout 30s, usually it takes ~25s for calibration
-	"$INSTALL/tools/ecu-reset" -s "$CAN"
-fi
-
 if [ "$CAN" = "cansim" ]; then
 	echo "### Starting VAL Seat Service [$SERVICE_HOST:$SERVICE_PORT] on Simulated SocketCAN!"
-	exec stdbuf --output=L $INSTALL/tools/cansim $INSTALL/seat_service "$CAN" "$SERVICE_HOST" $SERVICE_PORT
+	exec stdbuf --output=L "$INSTALL/tools/cansim" "$INSTALL/seat_service" "$CAN" "$SERVICE_HOST" $SERVICE_PORT
 else
+	### Calibrate motor before service start (needs to be done after ECU reset, or not in learned state)
+	if [ "$SC_RESET" != "0" ]; then
+		echo "### Calibrating ECU on $CAN"
+		# timeout 30s, usually it takes ~25s for calibration
+		"$INSTALL/tools/ecu-reset" -s "$CAN"
+	fi
 	echo "### Starting VAL Seat Service [$SERVICE_HOST:$SERVICE_PORT] on $CAN..."
-	exec stdbuf --output=L $INSTALL/seat_service "$CAN" "$SERVICE_HOST" $SERVICE_PORT
+	exec stdbuf --output=L "$INSTALL/seat_service" "$CAN" "$SERVICE_HOST" "$SERVICE_PORT"
 fi


### PR DESCRIPTION
- Dockerfile: Added can-utils to the image, Fixed ubuntu base version to be compatible with build version
- fixed seat controller scripts to use /bin/sh
- Added "SC_RESET" env variable to disable running ecu-reset script from val_start.sh. Enabled by default.
- Improved sim-SECU1_STAT to support testing for ecu-reset script without hardware
- updated relevant READMEs